### PR TITLE
fix: Add index.ts for PayloadCMS module resolution

### DIFF
--- a/backend/src/modules/payloadcms/index.ts
+++ b/backend/src/modules/payloadcms/index.ts
@@ -1,0 +1,2 @@
+import PayloadCMSModuleService from "./service";
+export default PayloadCMSModuleService;


### PR DESCRIPTION
The previous commit was failing to load the PayloadCMS module due to a missing entry point. This commit adds an `index.ts` file in the `backend/src/modules/payloadcms/` directory, which exports the `PayloadCMSModuleService`.

This allows Medusa's module loader to correctly resolve the module when using the path `resolve: "./modules/payloadcms"` in `medusa-config.ts`.